### PR TITLE
[CHORE] Add comprehensive DEBUG logging for development

### DIFF
--- a/src/CommandRouter.cpp
+++ b/src/CommandRouter.cpp
@@ -162,7 +162,7 @@ void CommandRouter::handleNick(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleUser(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -198,7 +198,7 @@ void CommandRouter::handleUser(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleJoin(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -294,7 +294,7 @@ void CommandRouter::handleJoin(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handlePart(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -358,7 +358,7 @@ void CommandRouter::handlePart(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handlePrivmsg(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -435,7 +435,7 @@ void CommandRouter::handlePrivmsg(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleKick(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -520,7 +520,7 @@ void CommandRouter::handleKick(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleInvite(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -590,7 +590,7 @@ void CommandRouter::handleInvite(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleTopic(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -665,7 +665,7 @@ void CommandRouter::handleTopic(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleMode(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -763,7 +763,7 @@ void CommandRouter::handleMode(User* user, const Command& cmd) {
 }
 
 void CommandRouter::handleQuit(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];
@@ -817,7 +817,7 @@ void CommandRouter::handleQuit(User* user, const Command& cmd) {
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void CommandRouter::handleCap(User* user, const Command& cmd) {
-  std::string params = "";
+  std::string params;
   for (size_t i = 0; i < cmd.params.size(); ++i) {
     if (i > 0) params += ", ";
     params += cmd.params[i];


### PR DESCRIPTION
## Summary
Added comprehensive DEBUG-level logging for all IRC commands and broadcast operations to facilitate debugging during development.

## Changes

### 1. Command Handler Entry Point Logging
All command handlers now log their entry with full parameter details:

**Example outputs:**
- `PASS command from 192.168.1.1 (password hidden for security)`
- `NICK command from 192.168.1.1 params: [alice]`
- `USER command from 192.168.1.1 params: [alice, 0, *, Alice User]`
- `JOIN command from alice params: [#channel, key]`
- `PRIVMSG command from alice params: [#channel, Hello everyone!]`
- `MODE command from alice params: [#channel, +o, bob]`
- `QUIT command from alice params: [Goodbye]`
- `CAP command from 192.168.1.1 params: [LS, 302]`

### 2. Broadcast Operation Logging
All broadcast operations log when they occur:
- `Broadcasting JOIN to #channel`
- `Broadcasting PART from #channel`
- `Broadcasting PRIVMSG to #channel`
- `Broadcasting KICK to #channel`
- `Broadcasting TOPIC to #channel`
- `Broadcasting QUIT from alice`

### 3. PING/PONG Logging
- Downgraded PING/PONG logs from INFO to DEBUG level
- Prevents log noise (PING sent every 30-60 seconds)
- Still shows full details when DEBUG is enabled

## Security Considerations
✅ **PASS command**: Password is NEVER logged (only shows IP address)  
⚠️ **PRIVMSG content**: Message content IS logged for development debugging  
⚠️ **Production**: Message content should be excluded for privacy in production

## Benefits
- **Complete visibility**: Track all IRC protocol interactions
- **Debug-friendly**: Identify command processing issues quickly
- **Development mode**: All details visible at DEBUG level
- **Production-safe**: DEBUG level off by default, no performance impact

## Test Plan
- [x] Compiled successfully with C++98
- [x] All commands log entry with parameters
- [x] All broadcasts log execution
- [x] PASS password is hidden
- [ ] Manual testing with DEBUG log level enabled

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)